### PR TITLE
Implementing StopWatch For Browser

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const INVALID_PERFORMANCE_NOW_VALUE = -1;
+export const INVALID_TIME_STAMP = -1;
+export const INVALID_STOP_WATCH_ELAPSED_TIME = -1;

--- a/src/implementations/JavaScriptEnvironmentCheckerImpl.ts
+++ b/src/implementations/JavaScriptEnvironmentCheckerImpl.ts
@@ -1,0 +1,13 @@
+import { JavaScriptEnvironmentChecker } from "../interfaces/JavaScriptEnvironmentChecker";
+
+export class JavaScriptEnvironmentCheckerImpl
+  implements JavaScriptEnvironmentChecker
+{
+  public isEnvironmentNodeJS(): boolean {
+    return (
+      process !== undefined &&
+      process.versions !== undefined &&
+      process.versions.node !== undefined
+    );
+  }
+}

--- a/src/implementations/PerformanceAPIWrapperImpl.ts
+++ b/src/implementations/PerformanceAPIWrapperImpl.ts
@@ -1,0 +1,20 @@
+import { PerformanceAPIWrapper } from "../interfaces/PerformanceAPIWrapper";
+import { JavaScriptEnvironmentChecker } from "../interfaces/JavaScriptEnvironmentChecker";
+
+export class PerformanceAPIWrapperImpl implements PerformanceAPIWrapper {
+  constructor(
+    private javaScriptEnvironmentChecker: JavaScriptEnvironmentChecker
+  ) {}
+  public isPerformanceDefined(): boolean {
+    return (
+      !this.javaScriptEnvironmentChecker.isEnvironmentNodeJS() &&
+      performance !== undefined
+    );
+  }
+  public isPerformanceNowDefined(): boolean {
+    return "now" in performance;
+  }
+  public getPerformanceNow(): number {
+    return performance.now();
+  }
+}

--- a/src/implementations/StopWatchFactoryImpl.ts
+++ b/src/implementations/StopWatchFactoryImpl.ts
@@ -1,0 +1,22 @@
+import { StopWatchFactory } from "../interfaces/StopWatchFactory";
+import { StopWatch } from "../interfaces/StopWatch";
+import { TimeStampRetriever } from "../interfaces/TimeStampRetriever";
+import { TimeStampRetrieverImpl } from "./TimeStampRetrieverImpl";
+import { PerformanceAPIWrapper } from "../interfaces/PerformanceAPIWrapper";
+import { PerformanceAPIWrapperImpl } from "./PerformanceAPIWrapperImpl";
+import { JavaScriptEnvironmentChecker } from "../interfaces/JavaScriptEnvironmentChecker";
+import { JavaScriptEnvironmentCheckerImpl } from "./JavaScriptEnvironmentCheckerImpl";
+import { StopWatchImpl } from "./StopWatchImpl";
+
+export class StopWatchFactoryImpl implements StopWatchFactory {
+  public createStopWatch(): StopWatch {
+    const javaScriptEnvironmentChecker: JavaScriptEnvironmentChecker =
+      new JavaScriptEnvironmentCheckerImpl();
+    const performanceAPIWrapper: PerformanceAPIWrapper =
+      new PerformanceAPIWrapperImpl(javaScriptEnvironmentChecker);
+    const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
+      performanceAPIWrapper
+    );
+    return new StopWatchImpl(timeStampRetriever);
+  }
+}

--- a/src/implementations/StopWatchImpl.ts
+++ b/src/implementations/StopWatchImpl.ts
@@ -1,0 +1,34 @@
+import { StopWatch } from "../interfaces/StopWatch";
+import { TimeStampRetriever } from "../interfaces/TimeStampRetriever";
+import { INVALID_STOP_WATCH_ELAPSED_TIME } from "../constants";
+
+export class StopWatchImpl implements StopWatch {
+  private startCalled: boolean;
+  private startTimeStamp: number | undefined;
+  private stopTimeStamp: number | undefined;
+  constructor(private timeStampRetriever: TimeStampRetriever) {
+    this.startCalled = false;
+    this.startTimeStamp = undefined;
+    this.stopTimeStamp = undefined;
+  }
+  public start(): void {
+    this.startTimeStamp = this.timeStampRetriever.getCurrentTimeStamp();
+    this.startCalled = true;
+  }
+  public stop(): void {
+    if (!this.startCalled) {
+      return;
+    }
+    this.stopTimeStamp = this.timeStampRetriever.getCurrentTimeStamp();
+  }
+  public getElapsedTimeInMilliSeconds(): number {
+    if (this.startTimeStamp === undefined || this.stopTimeStamp === undefined) {
+      return INVALID_STOP_WATCH_ELAPSED_TIME;
+    }
+    const elapsedTime: number = this.stopTimeStamp - this.startTimeStamp;
+    this.startTimeStamp = undefined;
+    this.stopTimeStamp = undefined;
+    this.startCalled = false;
+    return elapsedTime;
+  }
+}

--- a/src/implementations/TimeStampRetrieverImpl.ts
+++ b/src/implementations/TimeStampRetrieverImpl.ts
@@ -1,0 +1,17 @@
+import { TimeStampRetriever } from "../interfaces/TimeStampRetriever";
+import { PerformanceAPIWrapper } from "../interfaces/PerformanceAPIWrapper";
+import { INVALID_TIME_STAMP } from "../constants";
+
+export class TimeStampRetrieverImpl implements TimeStampRetriever {
+  private isPerformanceAPIAvailable: boolean;
+  constructor(private performanceAPIWrapper: PerformanceAPIWrapper) {
+    this.isPerformanceAPIAvailable =
+      performanceAPIWrapper.isPerformanceDefined() &&
+      performanceAPIWrapper.isPerformanceNowDefined();
+  }
+  public getCurrentTimeStamp(): number {
+    return this.isPerformanceAPIAvailable
+      ? this.performanceAPIWrapper.getPerformanceNow()
+      : INVALID_TIME_STAMP;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,6 @@
-// Empty file for now
+import { StopWatchFactory } from "./interfaces/StopWatchFactory";
+import { StopWatchFactoryImpl } from "./implementations/StopWatchFactoryImpl";
+
+export function getStopWatchFactory(): StopWatchFactory {
+  return new StopWatchFactoryImpl();
+}

--- a/src/interfaces/JavaScriptEnvironmentChecker.ts
+++ b/src/interfaces/JavaScriptEnvironmentChecker.ts
@@ -1,0 +1,3 @@
+export interface JavaScriptEnvironmentChecker {
+  isEnvironmentNodeJS(): boolean;
+}

--- a/src/interfaces/PerformanceAPIWrapper.ts
+++ b/src/interfaces/PerformanceAPIWrapper.ts
@@ -1,0 +1,5 @@
+export interface PerformanceAPIWrapper {
+  isPerformanceDefined(): boolean;
+  isPerformanceNowDefined(): boolean;
+  getPerformanceNow(): number;
+}

--- a/src/interfaces/StopWatch.ts
+++ b/src/interfaces/StopWatch.ts
@@ -1,0 +1,5 @@
+export interface StopWatch {
+  start(): void;
+  stop(): void;
+  getElapsedTimeInMilliSeconds(): number;
+}

--- a/src/interfaces/StopWatchFactory.ts
+++ b/src/interfaces/StopWatchFactory.ts
@@ -1,0 +1,5 @@
+import { StopWatch } from "./StopWatch";
+
+export interface StopWatchFactory {
+  createStopWatch(): StopWatch;
+}

--- a/src/interfaces/TimeStampRetriever.ts
+++ b/src/interfaces/TimeStampRetriever.ts
@@ -1,0 +1,3 @@
+export interface TimeStampRetriever {
+  getCurrentTimeStamp(): number;
+}

--- a/test/StopWatch.test.ts
+++ b/test/StopWatch.test.ts
@@ -1,0 +1,36 @@
+import { StopWatch } from "../src/interfaces/StopWatch";
+import { TimeStampRetriever } from "../src/interfaces/TimeStampRetriever";
+import { StopWatchImpl } from "../src/implementations/StopWatchImpl";
+import { TimeStampRetrieverStub } from "./stubs/TimeStampRetrieverStub";
+import { INVALID_STOP_WATCH_ELAPSED_TIME } from "../src/constants";
+
+test("should return invalid elapsed time if start was never called", () => {
+  const timeStampRetrieverStub: TimeStampRetriever =
+    new TimeStampRetrieverStub();
+  const stopWatch: StopWatch = new StopWatchImpl(timeStampRetrieverStub);
+  stopWatch.stop();
+  expect(stopWatch.getElapsedTimeInMilliSeconds()).toBe(
+    INVALID_STOP_WATCH_ELAPSED_TIME
+  );
+});
+
+test("should return invalid elapsed time if stop was never called", () => {
+  const timeStampRetrieverStub: TimeStampRetriever =
+    new TimeStampRetrieverStub();
+  const stopWatch: StopWatch = new StopWatchImpl(timeStampRetrieverStub);
+  stopWatch.start();
+  expect(stopWatch.getElapsedTimeInMilliSeconds()).toBe(
+    INVALID_STOP_WATCH_ELAPSED_TIME
+  );
+});
+
+test("should return a valid elapsed time if both start and stop were called", () => {
+  const timeStampRetrieverStub: TimeStampRetriever =
+    new TimeStampRetrieverStub();
+  const stopWatch: StopWatch = new StopWatchImpl(timeStampRetrieverStub);
+  stopWatch.start();
+  stopWatch.stop();
+  expect(stopWatch.getElapsedTimeInMilliSeconds()).not.toBe(
+    INVALID_STOP_WATCH_ELAPSED_TIME
+  );
+});

--- a/test/StopWatchFactory.test.ts
+++ b/test/StopWatchFactory.test.ts
@@ -1,0 +1,10 @@
+import { StopWatchFactory } from "../src/interfaces/StopWatchFactory";
+import { StopWatchFactoryImpl } from "../src/implementations/StopWatchFactoryImpl";
+import { StopWatch } from "../src/interfaces/StopWatch";
+import { StopWatchImpl } from "../src/implementations/StopWatchImpl";
+
+test("should produce an instance of StopWatchImpl", () => {
+  const stopWatchFactory: StopWatchFactory = new StopWatchFactoryImpl();
+  const stopWatch: StopWatch = stopWatchFactory.createStopWatch();
+  expect(stopWatch instanceof StopWatchImpl).toBe(true);
+});

--- a/test/TimeStampRetriever.test.ts
+++ b/test/TimeStampRetriever.test.ts
@@ -1,0 +1,37 @@
+import { TimeStampRetriever } from "../src/interfaces/TimeStampRetriever";
+import { TimeStampRetrieverImpl } from "../src/implementations/TimeStampRetrieverImpl";
+import { PerformanceAPIWrapper } from "../src/interfaces/PerformanceAPIWrapper";
+import { MockPerformanceAPIWrapper } from "./mocks/MockPerformanceAPIWrapper";
+import { PerformanceAPIWrapperStub } from "./stubs/PerformanceAPIWrapperStub";
+import { INVALID_TIME_STAMP } from "../src/constants";
+
+test("If performance is not defined, then the time stamp retriever should return invalid timestamp", () => {
+  const mockPerformanceAPIWrapper: MockPerformanceAPIWrapper =
+    new MockPerformanceAPIWrapper();
+  mockPerformanceAPIWrapper.failPerformanceDefinedCheck();
+  const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
+    mockPerformanceAPIWrapper
+  );
+  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(INVALID_TIME_STAMP);
+});
+
+test("If performance.now is not defined, then the time stamp retriever should return invalid timestamp", () => {
+  const mockPerformanceAPIWrapper: MockPerformanceAPIWrapper =
+    new MockPerformanceAPIWrapper();
+  mockPerformanceAPIWrapper.failPerformanceNowDefinedCheck();
+  const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
+    mockPerformanceAPIWrapper
+  );
+  expect(timeStampRetriever.getCurrentTimeStamp()).toEqual(INVALID_TIME_STAMP);
+});
+
+test("If both performance and performance.now is defined, then ", () => {
+  const performanceAPIWrapper: PerformanceAPIWrapper =
+    new PerformanceAPIWrapperStub();
+  const timeStampRetriever: TimeStampRetriever = new TimeStampRetrieverImpl(
+    performanceAPIWrapper
+  );
+  expect(timeStampRetriever.getCurrentTimeStamp()).not.toEqual(
+    INVALID_TIME_STAMP
+  );
+});

--- a/test/getStopWatchFactory.test.ts
+++ b/test/getStopWatchFactory.test.ts
@@ -1,0 +1,6 @@
+import { getStopWatchFactory } from "../src/index";
+import { StopWatchFactoryImpl } from "../src/implementations/StopWatchFactoryImpl";
+
+test("should produce an instance of StopWatchFactoryImpl", () => {
+  expect(getStopWatchFactory() instanceof StopWatchFactoryImpl).toBe(true);
+});

--- a/test/mocks/MockPerformanceAPIWrapper.ts
+++ b/test/mocks/MockPerformanceAPIWrapper.ts
@@ -1,0 +1,26 @@
+import { PerformanceAPIWrapper } from "../../src/interfaces/PerformanceAPIWrapper";
+import { INVALID_PERFORMANCE_NOW_VALUE } from "../../src/constants";
+
+export class MockPerformanceAPIWrapper implements PerformanceAPIWrapper {
+  private performanceDefinedCheckShouldPass: boolean;
+  private performanceNowDefinedCheckShouldPass: boolean;
+  constructor() {
+    this.performanceDefinedCheckShouldPass = true;
+    this.performanceNowDefinedCheckShouldPass = true;
+  }
+  public isPerformanceDefined(): boolean {
+    return this.performanceDefinedCheckShouldPass;
+  }
+  public isPerformanceNowDefined(): boolean {
+    return this.performanceNowDefinedCheckShouldPass;
+  }
+  public getPerformanceNow(): number {
+    return INVALID_PERFORMANCE_NOW_VALUE;
+  }
+  public failPerformanceDefinedCheck(): void {
+    this.performanceDefinedCheckShouldPass = false;
+  }
+  public failPerformanceNowDefinedCheck(): void {
+    this.performanceNowDefinedCheckShouldPass = false;
+  }
+}

--- a/test/stubs/PerformanceAPIWrapperStub.ts
+++ b/test/stubs/PerformanceAPIWrapperStub.ts
@@ -1,0 +1,14 @@
+import { PerformanceAPIWrapper } from "../../src/interfaces/PerformanceAPIWrapper";
+
+export class PerformanceAPIWrapperStub implements PerformanceAPIWrapper {
+  public isPerformanceDefined(): boolean {
+    return true;
+  }
+  public isPerformanceNowDefined(): boolean {
+    return true;
+  }
+  public getPerformanceNow(): number {
+    const dummyPerformanceNowValue = 0;
+    return dummyPerformanceNowValue;
+  }
+}

--- a/test/stubs/TimeStampRetrieverStub.ts
+++ b/test/stubs/TimeStampRetrieverStub.ts
@@ -1,0 +1,8 @@
+import { TimeStampRetriever } from "../../src/interfaces/TimeStampRetriever";
+
+export class TimeStampRetrieverStub implements TimeStampRetriever {
+  public getCurrentTimeStamp(): number {
+    const dummyTimeStamp = 0;
+    return dummyTimeStamp;
+  }
+}


### PR DESCRIPTION
Adding a browser implementation of the stopwatch. You can generate one or more instances of the stopwatch by using the factory object. 

The current implementation doesn't work for Node.js because `performance.now` is not a global in Node.js. This will fixed later. 